### PR TITLE
Only walk on floor

### DIFF
--- a/Assets/Scripts/Models/Tile.cs
+++ b/Assets/Scripts/Models/Tile.cs
@@ -85,6 +85,20 @@ public class Tile :IXmlSerializable, ISelectable
             //if (Type == TileType.Empty)
             //    return 0;	// 0 is unwalkable
 
+            if(Type == TileType.Empty)
+            {
+                Tile[] ns = GetNeighbours();
+
+                float movCost = 0f;
+
+                foreach (Tile n in ns)
+                {
+                    movCost += (n != null && n.Type == TileType.Floor) ? baseTileMovementCost : 0f;
+                }
+
+                return Mathf.Clamp(movCost, 0f, baseTileMovementCost);
+            }
+
             if (furniture == null)
                 return baseTileMovementCost;
 

--- a/Assets/Scripts/Models/Tile.cs
+++ b/Assets/Scripts/Models/Tile.cs
@@ -89,14 +89,14 @@ public class Tile :IXmlSerializable, ISelectable
             {
                 Tile[] ns = GetNeighbours();
 
-                float movCost = 0f;
+                bool canMove = false;
 
-                foreach (Tile n in ns)
+                foreach (Tile n in ns) // Loop through all the horizontal/vertical neighbours of the empty tile.
                 {
-                    movCost += (n != null && n.Type == TileType.Floor) ? baseTileMovementCost : 0f;
+                    canMove = canMove || (n != null && n.Type == TileType.Floor); // If the neighbour is a floor tile, set canMove to true.
                 }
 
-                return Mathf.Clamp(movCost, 0f, baseTileMovementCost);
+                return canMove ? baseTileMovementCost : 0f; // If canMove is true, return baseTileMovementCost, else, return 0f.
             }
 
             if (furniture == null)


### PR DESCRIPTION
The character can only walk on floors and empty tiles directly adjacent to floor tiles.
This was the easiest way I could think of to still allow building floors.

The character will still 'jump' over a gap of up to 2 tiles.